### PR TITLE
Don't display length for single address

### DIFF
--- a/src/cidr/direct.rs
+++ b/src/cidr/direct.rs
@@ -125,7 +125,11 @@ macro_rules! impl_cidr_for {
 
 		impl fmt::Display for $n {
 			fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-				write!(f, "{}/{}", self.address, self.network_length)
+				write!(f, "{}", self.address)?;
+				if self.network_length != $family.len() {
+					write!(f, "/{}", self.network_length)?;
+				}
+				Ok(())
 			}
 		}
 

--- a/src/inet/direct.rs
+++ b/src/inet/direct.rs
@@ -146,7 +146,11 @@ macro_rules! impl_inet_for {
 
 		impl fmt::Display for $n {
 			fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-				write!(f, "{}/{}", self.address, self.network_length)
+				write!(f, "{}", self.address)?;
+				if self.network_length != $family.len() {
+					write!(f, "/{}", self.network_length)?;
+				}
+				Ok(())
 			}
 		}
 


### PR DESCRIPTION
Omit length in Display and human-readable serialisation for single-address networks (e.g. created via `IpCidr::new_host`).