### PR TITLE
Add support for property testing with `proptest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+- Add optional support for `proptest`
+  Use cidr = { version = "0.2.3", features = [ "proptest" ] }` to enable it.
+
 ## [0.2.2] - 2023-06-25
 
 - Make all functions const if possible

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,13 @@ appveyor = { repository = "stbuehler/rust-cidr" }
 
 [features]
 default = ["std"]
+proptest = ["dep:proptest", "dep:proptest-derive"]
 std = []
 
 [dependencies]
 bitstring = { version = "0.1.0", optional = true }
+proptest = { version = "1.4.0", optional = true, default-features = false, features = ["std"] }
+proptest-derive = { version = "0.4.0", optional = true }
 serde = { version = "1.0.27", optional = true }
 
 [dev-dependencies]

--- a/src/cidr/any.rs
+++ b/src/cidr/any.rs
@@ -28,6 +28,7 @@ use crate::{
 ///
 /// [`Cidr`]: crate::Cidr
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum AnyIpCidr {
 	/// "any" network containing all IPv4 and IPv6 addresses
 	Any,

--- a/src/cidr/mod.rs
+++ b/src/cidr/mod.rs
@@ -23,6 +23,7 @@ use std::net::{
 ///
 /// [`Cidr`]: crate::Cidr
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Ipv4Cidr {
 	pub(crate) address: Ipv4Addr,
 	pub(crate) network_length: u8,
@@ -34,6 +35,7 @@ pub struct Ipv4Cidr {
 ///
 /// [`Cidr`]: crate::Cidr
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Ipv6Cidr {
 	pub(crate) address: Ipv6Addr,
 	pub(crate) network_length: u8,
@@ -43,6 +45,7 @@ pub struct Ipv6Cidr {
 ///
 /// [`Cidr`]: crate::Cidr
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum IpCidr {
 	/// IPv4 network
 	V4(Ipv4Cidr),

--- a/src/family.rs
+++ b/src/family.rs
@@ -6,6 +6,7 @@ use std::net::{
 
 /// Represents the type of an IP address
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum Family {
 	/// IPv4
 	Ipv4,

--- a/src/inet/mod.rs
+++ b/src/inet/mod.rs
@@ -18,6 +18,7 @@ use std::net::{
 ///
 /// [`Inet`]: crate::Inet
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Ipv4Inet {
 	pub(crate) address: Ipv4Addr,
 	pub(crate) network_length: u8,
@@ -30,6 +31,7 @@ pub struct Ipv4Inet {
 ///
 /// [`Inet`]: crate::Inet
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Ipv6Inet {
 	pub(crate) address: Ipv6Addr,
 	pub(crate) network_length: u8,
@@ -40,6 +42,7 @@ pub struct Ipv6Inet {
 ///
 /// [`Inet`]: crate::Inet
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum IpInet {
 	/// IPv4 host within network
 	V4(Ipv4Inet),

--- a/src/inet_pair/mod.rs
+++ b/src/inet_pair/mod.rs
@@ -10,6 +10,7 @@ use std::net::{
 ///
 /// [`InetPair`]: crate::InetPair
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Ipv4InetPair {
 	pub(crate) first: Ipv4Addr,
 	pub(crate) second: Ipv4Addr,
@@ -20,6 +21,7 @@ pub struct Ipv4InetPair {
 ///
 /// [`InetPair`]: crate::InetPair
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Ipv6InetPair {
 	pub(crate) first: Ipv6Addr,
 	pub(crate) second: Ipv6Addr,
@@ -31,6 +33,7 @@ pub struct Ipv6InetPair {
 ///
 /// [`InetPair`]: crate::InetPair
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum IpInetPair {
 	/// IPv4 host within network
 	V4(Ipv4InetPair),

--- a/src/num.rs
+++ b/src/num.rs
@@ -2,6 +2,7 @@
 ///
 /// Can be 2^128, so a u128 isn't enough - we need one more.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum NumberOfAddresses {
 	/// Given amount
 	Count(u128),


### PR DESCRIPTION
This allows for generation of arbitrary data types that contain CIDR types.