### PR TITLE
src/cidr/direct.rs:  impl PartialEq<$addr> and PartialOrd<$addr> for $n

### DIFF
--- a/src/cidr/direct.rs
+++ b/src/cidr/direct.rs
@@ -262,6 +262,20 @@ macro_rules! impl_cidr_for {
 			}
 		}
 
+		impl PartialEq<$addr> for $n {
+			#[inline]
+			fn eq(&self, other: &$addr) -> bool {
+				self.address.eq(other)
+			}
+		}
+
+		impl PartialOrd<$addr> for $n {
+			#[inline]
+			fn partial_cmp(&self, other: &$addr) -> Option<core::cmp::Ordering> {
+				Some(self.address.cmp(other))
+			}
+		}
+
 		impl Ord for $n {
 			fn cmp(&self, other: &Self) -> core::cmp::Ordering {
 				self.address


### PR DESCRIPTION
For a use case involving a long list of blocked/allowed address blocks, having these impls allows calling code to use binary search instead of linear, which can improve performance on large enough lists

Example calling code
```rust
fn is_ip_allowed(addr: &Ipv4Addr) -> bool {
    IP_BLOCKLIST
        .binary_search_by(|c| match c.contains(addr) {
            true => Ordering::Equal,
            false => c.partial_cmp(addr).unwrap(),
        })
        .is_ok()
}
```

With 64 CIDR blocks, binary search is about 10% faster, at least on my machine (Thinkpad w/ i7-1270P)